### PR TITLE
Feature/directory index support

### DIFF
--- a/handlers/case_directory.py
+++ b/handlers/case_directory.py
@@ -1,0 +1,17 @@
+import os
+from handlers.base_case import BaseCase
+
+class CaseDirectoryIndexFile(BaseCase):
+    """
+    Serves index.html when a directory request contains one.
+        
+    If a user requests a directory (e.g., /pages/) and that directory 
+    does not contain an 'index.html', this handler will serve 
+    'index.html' from the parent directory.
+    """
+    
+    def test(self, handler):
+        pass  # Logic coming in next commit
+
+    def act(self, handler):
+        pass  # Logic coming in next commit

--- a/handlers/case_directory.py
+++ b/handlers/case_directory.py
@@ -11,7 +11,7 @@ class CaseDirectoryIndexFile(BaseCase):
     """
     
     def test(self, handler):
-        pass  # Logic coming in next commit
+        pass 
 
     def act(self, handler):
-        pass  # Logic coming in next commit
+        pass

--- a/handlers/case_directory.py
+++ b/handlers/case_directory.py
@@ -11,7 +11,24 @@ class CaseDirectoryIndexFile(BaseCase):
     """
     
     def test(self, handler):
-        pass 
+        """
+        Checks if the request path is a directory AND contains index.html.
+        """
+        # 1. Is the requested path a directory?
+        is_dir = os.path.isdir(handler.full_path)
+        
+        # 2. Does index.html exist inside it? 
+        # (We use the helper method index_path() from BaseCase)
+        has_index = os.path.isfile(self.index_path(handler))
+        
+        return is_dir and has_index
 
     def act(self, handler):
-        pass
+        """
+        Serves the index.html file.
+        """
+        # Calculate the path to index.html
+        full_path = self.index_path(handler)
+        
+        # Use the helper method from BaseCase to send the file
+        self.handle_file(handler, full_path)

--- a/server.py
+++ b/server.py
@@ -1,12 +1,12 @@
+import os
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from handlers.base_case import BaseCase
-
+from handlers.case_directory import CaseDirectoryIndexFile
 
 class RequestHandler(BaseHTTPRequestHandler):
-    """Handle HTTP requests."""
+    """Main HTTP request handler for the server."""
     
     def send_content(self, content, status=200):
-        """Send content to the client."""
+        """Sends HTTP response with content to the client."""
         self.send_response(status)
         self.send_header("Content-type", "text/html")
         self.send_header("Content-Length", str(len(content)))
@@ -14,14 +14,23 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(content)
     
     def handle_error(self, msg):
-        """Send a 404 error message."""
+        """Sends a 404 error message."""
         content = f"Error: {msg}".encode('utf-8')
         self.send_content(content, 404)
     
     def do_GET(self):
         """Handle GET requests."""
-        message = "<h1>Server is running. BaseCase setup complete.</h1>"
-        self.send_content(message.encode('utf-8'))
+        # Calculate absolute path to requested file
+        self.full_path = os.getcwd() + self.path
+        
+        # Try to handle directory index request
+        case = CaseDirectoryIndexFile()
+        if case.test(self):
+            case.act(self)
+        else:
+            # Fallback when no index.html found
+            msg = "Not Found:Directory does not contain an index.html file"
+            self.handle_error(msg)
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -29,7 +29,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             case.act(self)
         else:
             # Fallback when no index.html found
-            msg = "Not Found:Directory does not contain an index.html file"
+            msg = "Directory does not contain an index.html file"
             self.handle_error(msg)
 
 

--- a/www/pages/index.html
+++ b/www/pages/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nexus Server - Directory Test</title>
+  </head>
+  <body>
+    <h1>Nexus Server</h1>
+    <p><strong>Status:</strong> Operational</p>
+    <hr />
+
+    <h2>Directory Index Support Test</h2>
+    <p>
+      If you are reading this, the CaseDirectoryIndexFile handler is
+      successfully serving the index.html file from a subdirectory.
+    </p>
+  </body>
+</html>

--- a/www/pages/index.html
+++ b/www/pages/index.html
@@ -12,7 +12,7 @@
     <h2>Directory Index Support Test</h2>
     <p>
       If you are reading this, the CaseDirectoryIndexFile handler is
-      successfully serving the index.html file from a subdirectory.
+      successfully serving the index.html file from the /pages/ directory.
     </p>
   </body>
 </html>


### PR DESCRIPTION
Implemented directory index support as requested in Issue #5.

### Changes
* **`handlers/case_directory.py`**: Created `CaseDirectoryIndexFile` class.
    * Implemented `test()`: Checks if path is directory AND has index.html.
    * Implemented `act()`: Uses `BaseCase.handle_file` to serve the index.
* **`server.py`**: Updated `do_GET` to calculate `full_path` and invoke the directory handler.
* **Test Data**: Added `www/pages/index.html` for verification.

### Verification
* Verified that visiting `/www/pages/` automatically loads `index.html`.

Closes #5

<img width="1303" height="767" alt="image" src="https://github.com/user-attachments/assets/44ca3674-e1be-4975-9419-26a317f6c690" />
